### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -2,13 +2,13 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-HDSP2000Shield KEYWORD1
+HDSP2000Shield	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 begin	KEYWORD2
 end	KEYWORD2
-txtBuffer   KEYWORD2
+txtBuffer	KEYWORD2
 
-HDSP2000 LITERAL1
+HDSP2000	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords